### PR TITLE
Allow only PNG and JPG screenshots

### DIFF
--- a/wl/server/HandleCommand.java
+++ b/wl/server/HandleCommand.java
@@ -818,7 +818,7 @@ public class HandleCommand {
 					                                          cmd[3] + ", found " + checksum);
 				ServerUtils.checkEndOfStream(in);
 
-				String mimetype = Utils.bashOutput("mimetype", "--brief", file.getPath());
+				String mimetype = Utils.bashOutput("mimetype", "-M", "-b", file.getPath());
 				String extension;
 				switch (mimetype) {
 					case "image/png":

--- a/wl/server/HandleCommand.java
+++ b/wl/server/HandleCommand.java
@@ -828,7 +828,8 @@ public class HandleCommand {
 						extension = ".jpg";
 						break;
 					default:
-						throw new ServerUtils.WLProtocolException("Illegal image type '" + mimetype + "' (only PNG and JPG are allowed)");
+						throw new ServerUtils.WLProtocolException(
+						    "Illegal image type '" + mimetype + "' (only PNG and JPG are allowed)");
 				}
 
 				String filename;

--- a/wl/server/HandleCommand.java
+++ b/wl/server/HandleCommand.java
@@ -800,12 +800,7 @@ public class HandleCommand {
 			File tempDir = Files.createTempDirectory(null).toFile();
 
 			try {
-				String filename;
-				for (int i = 1;; ++i) {
-					filename = "image" + i + ".png";
-					if (!new File("screenshots/" + cmd[1], filename).exists()) break;
-				}
-				File file = new File(tempDir, filename);
+				File file = new File(tempDir, "image");
 				PrintStream stream = new PrintStream(file);
 				for (long l = 0; l < size; ++l) {
 					int b = in.read();
@@ -822,6 +817,25 @@ public class HandleCommand {
 					throw new ServerUtils.WLProtocolException("Checksum mismatch: expected " +
 					                                          cmd[3] + ", found " + checksum);
 				ServerUtils.checkEndOfStream(in);
+
+				String mimetype = Utils.bashOutput("mimetype", "--brief", file.getPath());
+				String extension;
+				switch (mimetype) {
+					case "image/png":
+						extension = ".png";
+						break;
+					case "image/jpeg":
+						extension = ".jpg";
+						break;
+					default:
+						throw new ServerUtils.WLProtocolException("Illegal image type '" + mimetype + "' (only PNG and JPG are allowed)");
+				}
+
+				String filename;
+				for (int i = 1;; ++i) {
+					filename = "image" + i + extension;
+					if (!new File("screenshots/" + cmd[1], filename).exists()) break;
+				}
 				File result = new File("screenshots", cmd[1]);
 				result.mkdirs();
 				result = new File(result, filename);


### PR DESCRIPTION
Fix #131

The `mimetype` command is not fooled by the file extension so it should be sufficient here.